### PR TITLE
Refactor/money

### DIFF
--- a/src/Cosmo.php
+++ b/src/Cosmo.php
@@ -256,18 +256,29 @@ class Cosmo extends Locale
     /**
      * @param float $value
      * @param string $currency The 3-letter ISO 4217 currency code indicating the currency to use.
+     * @param int|null $precision The needed number of decimals digits 
      * @param string|null $pattern
      * @return string
      * @throws Exception
      */
-    public function money(float $value, string $currency = null, string $pattern = ''): string
+    public function money(float $value, string $currency = null, int $precision= -1,  string $pattern = ''): string
     {
         $currency = $currency ?: $this->modifiers['currency'];
         if (!$currency) {
             throw new Exception("No currency is set to format the monetary value. Set the region subtag in the local identifier (e.g. en -> en_AU) 
                                                     or provide a valid currency code parameter.");
         }
-        return (new NumberFormatter($this->locale, NumberFormatter::CURRENCY, $pattern))->formatCurrency($value, $currency);
+
+        if (!is_int($precision)) {
+            throw new Exception("Wrong precision value ($precision). Integer expected");
+        }
+
+        $fmt = new NumberFormatter( $this->locale, NumberFormatter::CURRENCY);
+        $fmt->setTextAttribute( $fmt::CURRENCY_CODE, $currency );
+        if ($precision > -1) {
+            $fmt->setAttribute($fmt::FRACTION_DIGITS, $precision);
+        }
+        return $fmt->format($value);
     }
 
     /**

--- a/src/Cosmo.php
+++ b/src/Cosmo.php
@@ -261,7 +261,7 @@ class Cosmo extends Locale
      * @return string
      * @throws Exception
      */
-    public function money(float $value, string $currency = null, int $precision= -1,  string $pattern = ''): string
+    public function money(float $value, string $currency = null, int $precision = null,  string $pattern = ''): string
     {
         $currency = $currency ?: $this->modifiers['currency'];
         if (!$currency) {
@@ -269,16 +269,13 @@ class Cosmo extends Locale
                                                     or provide a valid currency code parameter.");
         }
 
-        if (!is_int($precision)) {
-            throw new Exception("Wrong precision value ($precision). Integer expected");
-        }
 
-        $fmt = new NumberFormatter( $this->locale, NumberFormatter::CURRENCY);
-        $fmt->setTextAttribute( $fmt::CURRENCY_CODE, $currency );
-        if ($precision > -1) {
-            $fmt->setAttribute($fmt::FRACTION_DIGITS, $precision);
+        $formatter = new NumberFormatter( $this->locale, NumberFormatter::CURRENCY);
+        $formatter->setTextAttribute( $fmt::CURRENCY_CODE, $currency );
+        if ($precision > 0) {
+            $formatter->setAttribute($fmt::FRACTION_DIGITS, $precision);
         }
-        return $fmt->format($value);
+        return $formatter->format($value);
     }
 
     /**

--- a/tests/CosmoTest.php
+++ b/tests/CosmoTest.php
@@ -113,6 +113,20 @@ class CosmoTest extends TestCase
 
         $actual = Cosmo::create('en_US')->money(12.3, 'aud');
         $this->assertEquals('A$12.30', $actual);
+
+        $actual = Cosmo::create('en_AU')->money(12.32342, 'aud');
+        $this->assertEquals('$12.32', $actual);
+        
+        $actual = Cosmo::create('en_AU')->money(12, 'aud');
+        $this->assertEquals('$12.00', $actual);
+
+        $actual = Cosmo::create('en_AU')->money(12.32342, 'aud', 0);
+        $this->assertEquals('$12', $actual);
+
+        $actual = Cosmo::create('en_AU')->money(12.62342, 'aud', 0);
+        $this->assertEquals('$13', $actual);
+
+        
     }
 
     public function testOrdinal()


### PR DESCRIPTION
Changed the implementation of the money method so that it will be possible to force the number of decimals of the format result.

In particular, my problem was to allow the method to return an integer alue (0 decimal digits).

If the precision is not specified the standard behavious is used