### PR TITLE
"Object of class ResourceBundle could not be converted to string" exception fix

### DIFF
--- a/src/Cosmo.php
+++ b/src/Cosmo.php
@@ -436,6 +436,9 @@ class Cosmo extends Locale
     {
         $categories = '';
         foreach ($bundle as $category => $string) {
+            if (!is_string($string)) {
+                continue;
+            }
             $categories .= "$category {{$string}}";
         }
         $categories = str_replace('{0}', '#', $categories);


### PR DESCRIPTION
PR fixes an exception "Object of class ResourceBundle could not be converted to string".

## Code to reproduce a bug:

```php
$cosmo = new Cosmo('de'); // may also be uk, ro, ru
echo $cosmo->unit('digital', 'byte', 123);
```

### Expected result:
123 Byte

### Actual result:
Exception "Object of class ResourceBundle could not be converted to string"