### PR TITLE
Bump version to 2.0 in changelog

### DIFF
--- a/src/Cosmo.php
+++ b/src/Cosmo.php
@@ -81,6 +81,7 @@ class Cosmo extends Locale
         $this->modifiers = $modifiers;
     }
 
+    #[\Deprecated('Use new Cosmo() directly — PHP 8.4 supports new Cosmo($locale)->method() without parentheses.')]
     public static function create(string $locale = null, array $modifiers = []): Cosmo
     {
         return new self($locale, $modifiers);


### PR DESCRIPTION
Remove deprecated customTime() and UNITE_TYPES for v2.0 PHP 8.4 as minimum requirement is a breaking change warranting a major version bump. Consolidated v1.3/v1.4 entries and expanded with all changes from this release cycle.

**Documentation & tooling** — Added a `readme.md` template and a `generate.php` script to auto-sync the readme with live sample code and output. Moved `sample.php` from the root into `doc/` with several small fixes.

**PHPDoc improvements** — Added missing docblocks across many methods, fixed typos (`en-Au` → `en_AU`, "scrip subtag", `$local` → `$locale`), corrected wrong/incomplete `@param` and `@throws` tags, and improved phrasing throughout.

**Bug fixes** — `money()` no longer silently fails when no currency is set (new `$strict` parameter); `moment()` calendar bug fixed (`?:` → `??`); `flag()` got a null guard; typo fixed in `currency()` error message; test bugs fixed (`$precison`, spurious extra args).

**Code quality** — Removed redundant `require_once`, replaced unsafe `constant()` calls in `symbol()` with reflection-based validation (with static cache), fixed a `UNITE_TYPES` typo (with deprecated alias kept), and cleaned up unnecessary parentheses.

**PHP modernisation** — Adopted PHP 8.0–8.4 features: `readonly` properties, typed class constants, `#[\Override]`/`#[\Deprecated]` attributes, `throw`-as-expression, named arguments, `match` expressions, and a `Sentinel` enum to replace the old `func_get_args()` sentinel pattern.

**Maintenance** — Bumped minimum PHP requirement to 8.4, updated the changelog with v1.2–v1.4 entries, and added Docker run instructions to the readme. Pin sample.php to UTC so readme output is reproducible across machines